### PR TITLE
fix: handle filtering and limit in sql for perf

### DIFF
--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,33 +1,46 @@
+import { sql } from "drizzle-orm";
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
-import { advocateData } from "../../../db/seed/advocates";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const searchTerm = searchParams.get("search")?.toLowerCase();
 
-  // Uncomment this line to use a database
-  let data = await db.select().from(advocates);
-
-  // Uncomment this line to use local data
-  // let data = advocateData;
+  // @ts-expect-error TODO: fix Drizzle ts issue
+  let query = db.select().from(advocates).limit(20);
 
   if (searchTerm) {
-    data = data.filter((advocate) => {
-      return (
-        advocate.firstName.toLowerCase().includes(searchTerm) ||
-        advocate.lastName.toLowerCase().includes(searchTerm) ||
-        `${advocate.firstName} ${advocate.lastName}`
-          .toLowerCase()
-          .includes(searchTerm) ||
-        advocate.city.toLowerCase().includes(searchTerm) ||
-        advocate.degree.toLowerCase().includes(searchTerm) ||
-        (Array.isArray(advocate.specialties) &&
-          advocate.specialties.join(" ").toLowerCase().includes(searchTerm)) ||
-        String(advocate.yearsOfExperience).includes(searchTerm)
-      );
-    });
+    query = db
+      .select()
+      .from(advocates)
+      // @ts-expect-error TODO: fix Drizzle ts issue
+      .where(
+        sql`
+          advocates.first_name ILIKE ${"%" + searchTerm + "%"}
+          OR advocates.last_name ILIKE ${"%" + searchTerm + "%"}
+          OR (advocates.first_name || ' ' || advocates.last_name) ILIKE ${
+            "%" + searchTerm + "%"
+          }
+          OR advocates.city ILIKE ${"%" + searchTerm + "%"}
+          OR advocates.degree ILIKE ${"%" + searchTerm + "%"}
+          OR (
+            CASE
+              WHEN jsonb_typeof(advocates.payload) = 'array'
+                THEN array_to_string(ARRAY(
+                  SELECT jsonb_array_elements_text(advocates.payload)
+                ), ' ')
+              ELSE advocates.payload::text
+            END
+          ) ILIKE ${"%" + searchTerm + "%"}
+          OR CAST(advocates.years_of_experience AS TEXT) ILIKE ${
+            "%" + searchTerm + "%"
+          }
+        `
+      )
+      .limit(20);
   }
+
+  const data = await query;
 
   return Response.json({ data });
 }


### PR DESCRIPTION
This pull request refactors the search and retrieval logic for advocates in the `src/app/api/advocates/route.ts` file to perform filtering directly in the database query rather than in application code. This improves performance and scalability, especially for larger datasets.

**Database query improvements:**

* Replaced in-memory filtering of the `advocates` data with a SQL query that uses `ILIKE` and other SQL features to perform case-insensitive and flexible search across multiple fields, including handling JSON array payloads for specialties.
* Limited the number of results returned from the database to 20 to optimize response time and resource usage.

**Codebase simplification:**

* Removed commented-out code for toggling between local and database data sources, streamlining the code to always use the database.